### PR TITLE
fix(hygiene): declare runtime deps, fix lxml-broken tests + lint, add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    env:
+      # The keychain tests exercise the real `keyring` API. A headless CI
+      # runner has no Secret Service / macOS Keychain, so point keyring at a
+      # non-interactive file backend (from keyrings.alt, pulled in by the dev
+      # extra). Without this the keychain tests would hang or error.
+      PYTHON_KEYRING_BACKEND: keyrings.alt.file.PlaintextKeyring
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Installs runtime deps (httpx, beautifulsoup4, lxml, ...) plus the
+          # dev extra (pytest, pytest-asyncio, ruff, mypy, keyrings.alt). The
+          # heavy 'browser' extra (playwright) is intentionally NOT installed —
+          # it is lazily imported and not exercised by the test suite.
+          pip install -e ".[dev]"
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        # Run serially: several tests use real asyncio.sleep backoffs and the
+        # keychain tests are not fork-safe, so pytest-xdist is avoided here.
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,13 @@ pip-wheel-metadata/
 
 # Testing
 .pytest_cache/
+.ruff_cache/
 .coverage
 htmlcov/
 .mypy_cache/
+
+# Runtime artifacts (spec store, convergence snapshots)
+.specstore/
 
 # Node
 node_modules/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,27 @@ requires-python = ">=3.11"
 dependencies = [
     "typer>=0.12",
     "keyring>=24",
+    "httpx>=0.27",
+    "beautifulsoup4>=4.12",
+    "lxml>=5.2",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8",
+    "pytest-asyncio>=0.23",
     "ruff>=0.4",
     "mypy>=1.10",
+    # Non-interactive keyring backend for CI: the keychain tests exercise the
+    # real `keyring` API, which on a headless runner has no Secret Service /
+    # macOS Keychain. keyrings.alt provides a file/null backend so those tests
+    # run without prompting or crashing. Select it via PYTHON_KEYRING_BACKEND.
+    "keyrings.alt>=5.0",
+]
+# Heavy, lazily-imported browser-automation stack. Only needed for the
+# recon browser-explore / verification-gate paths; import-guarded elsewhere.
+browser = [
+    "playwright>=1.44",
 ]
 
 [project.scripts]
@@ -40,3 +54,4 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -378,14 +378,26 @@ def analyze(
 def model(
     target: str = typer.Argument(..., help="Target SaaS URL or domain"),
     scope: str = typer.Option("", "--scope", help="Comma-separated feature names to include"),
-    store: str = typer.Option(".", "--store", help="Root directory for .specstore (source of facts)"),
-    output_dir: str = typer.Option(".", "--output-dir", help="Directory to write model_v*.json snapshots"),
-    max_iterations: int = typer.Option(5, "--max-iterations", help="Max experiment-refine iterations"),
-    max_experiments: int = typer.Option(50, "--max-experiments", help="Max experiments per iteration"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Build model from facts only, skip experiments"),
+    store: str = typer.Option(
+        ".", "--store", help="Root directory for .specstore (source of facts)"
+    ),
+    output_dir: str = typer.Option(
+        ".", "--output-dir", help="Directory to write model_v*.json snapshots"
+    ),
+    max_iterations: int = typer.Option(
+        5, "--max-iterations", help="Max experiment-refine iterations"
+    ),
+    max_experiments: int = typer.Option(
+        50, "--max-experiments", help="Max experiments per iteration"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Build model from facts only, skip experiments"
+    ),
 ) -> None:
-    """Build domain model via scientific recon loop (observe → hypothesize → experiment → refine)."""
-    import json as _json
+    """Build domain model via scientific recon loop.
+
+    Loop: observe → hypothesize → experiment → refine.
+    """
 
     from scripts.fact_analyzer import FactAnalyzer
     from scripts.hypothesis_builder import HypothesisBuilder
@@ -422,7 +434,7 @@ def model(
         dm.iteration = 0
         snapshot = out / "model_v0.json"
         dm.save(snapshot)
-        typer.echo(f"\nDomain model (dry run):")
+        typer.echo("\nDomain model (dry run):")
         typer.echo(f"  Entities:     {len(dm.entities)}")
         typer.echo(f"  Hypotheses:   {dm.total_hypotheses()}")
         typer.echo(f"  Confidence:   {dm.overall_confidence():.0%}")
@@ -446,7 +458,7 @@ def model(
     final_path = out / "model_final.json"
     dm.save(final_path)
 
-    typer.echo(f"\nDomain model (final):")
+    typer.echo("\nDomain model (final):")
     typer.echo(f"  Entities:     {len(dm.entities)}")
     typer.echo(f"  Hypotheses:   {dm.total_hypotheses()}")
     typer.echo(f"  Validated:    {dm.validated_hypotheses()}")
@@ -499,7 +511,10 @@ def generate_tickets(
         return
 
     if not repo:
-        typer.echo("\nNo --repo specified. Use --dry-run to preview or --repo owner/repo to create issues.")
+        typer.echo(
+            "\nNo --repo specified. Use --dry-run to preview or "
+            "--repo owner/repo to create issues."
+        )
         return
 
     typer.echo(f"\nCreating GitHub issues in {repo} ...")

--- a/scripts/duplicate.py
+++ b/scripts/duplicate.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from scripts.compare import BehavioralComparator
 from scripts.converge import ConvergenceConfig, ConvergenceOrchestrator, ConvergenceReport
 from scripts.gap_analyzer import GapAnalyzer
-from scripts.models import BundleStatus, SpecBundle
+from scripts.models import BundleStatus, Fact, SpecBundle
 from scripts.scope import Scope, freeze_scope, parse_scope
 from scripts.spec_store import SpecStore
 from scripts.spec_synthesizer import SpecSynthesizer
@@ -627,9 +627,8 @@ class DuplicatePipeline:
         Analyze and curate facts using FactAnalyzer.
         """
         try:
-            from scripts.fact_analyzer import FactAnalyzer
             import scripts.keychain as keychain_module
-            from scripts.models import Fact
+            from scripts.fact_analyzer import FactAnalyzer
 
             analyzer = FactAnalyzer(spec_store, keychain_module)
 
@@ -650,7 +649,11 @@ class DuplicatePipeline:
                 return []
 
             analyzed_facts = await analyzer.analyze(all_raw_facts)
-            logger.info("Curation complete: %d raw -> %d analyzed facts", len(all_raw_facts), len(analyzed_facts))
+            logger.info(
+                "Curation complete: %d raw -> %d analyzed facts",
+                len(all_raw_facts),
+                len(analyzed_facts),
+            )
             return analyzed_facts
         except Exception as exc:  # noqa: BLE001
             msg = f"Fact analysis failed: {exc}"
@@ -673,7 +676,6 @@ class DuplicatePipeline:
         """
         try:
             import scripts.keychain as keychain_module
-            from scripts.models import Fact  # Ensure Fact is available
 
             synthesizer = SpecSynthesizer(
                 spec_store=spec_store,

--- a/scripts/hypothesis_builder.py
+++ b/scripts/hypothesis_builder.py
@@ -160,7 +160,11 @@ class HypothesisBuilder:
                 for field_name, field_type in seed.get("fields", {}).items():
                     entity.fields[field_name] = FieldHypothesis(
                         name=field_name,
-                        field_type=FieldType(field_type) if field_type in FieldType.__members__.values() else FieldType.STRING,
+                        field_type=(
+                            FieldType(field_type)
+                            if field_type in FieldType.__members__.values()
+                            else FieldType.STRING
+                        ),
                         evidence=["seeded"],
                     )
                 # Add seed relationships

--- a/scripts/recon/orchestrator.py
+++ b/scripts/recon/orchestrator.py
@@ -161,7 +161,9 @@ class ReconOrchestrator:
         auth failures gracefully via ReconResult.errors.
         """
         # Derive domain slug from target (e.g. "trello.com" → "trello-com")
-        domain_slug = target.replace("https://", "").replace("http://", "").split("/")[0].replace(".", "-")
+        domain_slug = (
+            target.replace("https://", "").replace("http://", "").split("/")[0].replace(".", "-")
+        )
 
         creds: dict[str, str] = {}
         for key in module.requires_credentials:

--- a/tests/test_interactive_explore.py
+++ b/tests/test_interactive_explore.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import uuid
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -23,8 +23,8 @@ from scripts.recon.base import (
     ReconServices,
 )
 from scripts.recon.interactive_explore import (
-    InteractiveElement,
     InteractionResult,
+    InteractiveElement,
     InteractiveExploreModule,
 )
 

--- a/tests/test_noise_filter_source.py
+++ b/tests/test_noise_filter_source.py
@@ -15,8 +15,7 @@ import uuid
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
-
+from scripts.hypothesis_builder import HypothesisBuilder, _is_product_entity
 from scripts.models import (
     Authority,
     EvidenceRef,
@@ -33,8 +32,6 @@ from scripts.recon.browser_explore import (
     CapturedRequest,
     NavigationStep,
 )
-from scripts.hypothesis_builder import HypothesisBuilder, _is_product_entity
-
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Fix the hygiene issues a code-quality audit found on `main`

A July-2026 `/code-metrics` audit graded this repo **B** — strong test authoring (1,127 real tests) undercut by an enforcement gap: **no CI**, so problems accumulated unnoticed on `main`. This fixes all of them and adds the CI that would have caught them.

### 1. Undeclared runtime dependencies (repo was `pip install`-broken)
`pyproject.toml` declared only `typer`+`keyring`, but the code imports `httpx` (8 modules), `beautifulsoup4` (3 recon modules), and `lxml` (bs4's `"xml"` parser). Added all three to `[project].dependencies`. `playwright` is deliberately an **optional `[browser]` extra** — every import is lazy/guarded, so a hard dep would be wrong.

### 2. The 2 failing tests
`test_help_center.py` sitemap tests failed with bs4 `FeatureNotFound: xml` — the missing `lxml`. Declaring it fixes them. **1,127 passed / 0 failed** (was 2 failing). No test weakened.

### 3. 21 → 0 ruff errors
Auto-fixed unused imports / f-strings / import-order; manually fixed the `Fact` `F821`/`F401` contradiction in `duplicate.py` (imported-but-unused vs used-in-annotation) and `E501` long lines.

### 4. CI (generated by chief-wiggum's `ci_scaffold.py`, then tuned)
New `.github/workflows/ci.yml`: `pip install -e ".[dev]"` → `ruff check` → `pytest`. Tuned for this repo — added `pytest-asyncio` (7 test files used `@pytest.mark.asyncio` with no plugin declared → ~90 async tests silently errored in a clean install) and a headless `keyrings.alt` backend so the keychain tests run non-interactively in CI.

## Verification (independently re-run)
- Clean `pip install -e ".[dev]"` + `import bs4, httpx, lxml` → OK
- `pytest -q` → **1,127 passed, 0 failed** (CI-faithful: file keyring backend, serial)
- `ruff check .` → **All checks passed**
- `ci.yml` parses; steps match what passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
